### PR TITLE
16 omega rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ C++ Implementation of the SQPnP algorithm.
 The algorithm is the generic PnP solver described in the paper ["A Consistently Fast and Globally Optimal Solution to the Perspective-n-Point Problem" by G. Terzakis and M. Lourakis](http://www.ecva.net/papers/eccv_2020/papers_ECCV/papers/123460460.pdf). For more intuition, refer to the supplementary material [here](https://www.ecva.net/papers/eccv_2020/papers_ECCV/papers/123460460-supp.pdf).
 
 ## Required libraries
-SQPnP requires the [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) library to build. Besides eigendecomposition, the use of Eigen is confined to matrix addition, transposition and multiplication.
+SQPnP requires the [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) library to build. Besides rank revealing QR and optionally SVD, the use of Eigen is confined to matrix addition, transposition and multiplication.
 Choosing Eigen was motivated by its increasing popularity and lightweight character. There are also three examples of using the solver in this repository:
 1. ) one that uses OpenCV, just for the sake of demonstrating the initialization of SQPnP with ``cv::Point_<>`` and ``cv::Point3_<>`` structures,
 2. ) another in which data points are copied from plain 2D arrays, and
@@ -13,7 +13,7 @@ Choosing Eigen was motivated by its increasing popularity and lightweight charac
 Build will proceed with either one of 1) or 2), depending on whether OpenCV is found or not.
 Example 3) uses the [RansacLib](https://github.com/tsattler/RansacLib) template-based library, (part of) which is included in this repository.
 
-Build
+## Build
 -----
 
 Create a ``build`` directory in the root of the cloned repository and run ``cmake``:
@@ -38,6 +38,16 @@ To run the PnP example, once in the ``build`` directory,
 
 To run the robust estimation example, from the ``build`` directory,
 ``./examples/robust_sqpnp_example data/K.txt data/32D.txt``
+
+## Non-default parameters
+See ``struct SolverParameters`` in ``types.h`` which contains SQPnP's parameters that can be specified by the caller.
+For instance, to use SVD instead of RRQR for the nullspace basis of Omega, the following fragment can be used:
+```c++
+  // call solver with user-specified parameters (and equal weights for all points)
+  sqpnp::SolverParameters params;
+  params.omega_nullspace_method = sqpnp::OmegaNullspaceMethod::SVD;
+  sqpnp::PnPSolver solver(points3d, points2d, std::vector<double>(n, 1.0), params);
+```
 
 ## Cite as
 If you use this code in your published work, please cite the following paper:<br><br>

--- a/sqpnp/sqpnp.cpp
+++ b/sqpnp/sqpnp.cpp
@@ -17,6 +17,7 @@ namespace sqpnp
   const double SolverParameters::DEFAULT_RANK_TOLERANCE = 1e-7;
   const double SolverParameters::DEFAULT_SQP_SQUARED_TOLERANCE = 1e-10;
   const double SolverParameters::DEFAULT_SQP_DET_THRESHOLD = 1.001;
+  const OmegaNullspaceMethod  SolverParameters::DEFAULT_OMEGA_NULLSPACE_METHOD = OmegaNullspaceMethod::RRQR;
   const NearestRotationMethod SolverParameters::DEFAULT_NEAREST_ROTATION_METHOD = NearestRotationMethod::FOAM;
   const double SolverParameters::DEFAULT_ORTHOGONALITY_SQUARED_ERROR_THRESHOLD = 1e-8;
   const double SolverParameters::DEFAULT_EQUAL_VECTORS_SQUARED_DIFF = 1e-10;
@@ -110,11 +111,9 @@ namespace sqpnp
       }
     }
 
-    int c = 1;
-    while (min_sq_error > 3 * s_[9 - num_eigen_points - c] && 9 - num_eigen_points - c > 0) 
+    int index, c = 1;
+    while ((index = 9 - num_eigen_points - c) > 0 && min_sq_error > 3 * s_[index]) 
     {      
-      int index = 9 - num_eigen_points - c;
-
       const Eigen::Matrix<double, 9, 1> e = Eigen::Map<Eigen::Matrix<double, 9, 1>>( U_.block<9, 1>(0, index).data() );
       SQPSolution solution[2];
       

--- a/sqpnp/sqpnp.h
+++ b/sqpnp/sqpnp.h
@@ -174,7 +174,8 @@ namespace sqpnp
       Omega_(3, 3) = Omega_(0, 0); Omega_(3, 4) = Omega_(0, 1); Omega_(3, 5) = Omega_(0, 2);
                                    Omega_(4, 4) = Omega_(1, 1); Omega_(4, 5) = Omega_(1, 2);
                                                                 Omega_(5, 5) = Omega_(2, 2);
-      // Fill lower triangle of Omega
+
+      // Fill lower triangle of Omega; elements (7, 6), (8, 6) & (8, 7) have already been assigned above
       Omega_(1, 0) = Omega_(0, 1);
       Omega_(2, 0) = Omega_(0, 2); Omega_(2, 1) = Omega_(1, 2);
       Omega_(3, 0) = Omega_(0, 3); Omega_(3, 1) = Omega_(1, 3); Omega_(3, 2) = Omega_(2, 3);
@@ -312,7 +313,6 @@ namespace sqpnp
       const auto& t = solution.t;
       const auto& M = point_mean_;
       return ( r[6]*M[0] + r[7]*M[1] + r[8]*M[2] + t[2] > 0 );
-	
     }
 
     //
@@ -331,7 +331,6 @@ namespace sqpnp
       }
 
       return npos >= nneg;
-	
     }
     
     //
@@ -368,7 +367,7 @@ namespace sqpnp
       t12 = c*c;
       double det = -t4*f+a*t2+t7*f-2.0*t9*e+t12*d;
       
-      if ( fabs(det) < det_threshold ) { Qinv=Q.completeOrthogonalDecomposition().pseudoInverse(); return true; } // fall back to pseudoinverse
+      if ( fabs(det) < det_threshold ) { Qinv=Q.completeOrthogonalDecomposition().pseudoInverse(); return false; } // fall back to pseudoinverse
  
       // 3. Inverse
       double t15, t20, t24, t30;
@@ -523,9 +522,8 @@ namespace sqpnp
 				      Eigen::Matrix<double, 9, 6>& H, 
 				      Eigen::Matrix<double, 9, 3>& N,
 				      Eigen::Matrix<double, 6, 6>& K,
-				const double& norm_threhsold = 0.1 );
-    
-    
+				const double& norm_threhsold = 0.1 ); 
+   
   };
   
 

--- a/sqpnp/sqpnp.h
+++ b/sqpnp/sqpnp.h
@@ -222,6 +222,7 @@ namespace sqpnp
       // Find dimension of null space; the check guards against overly large rank_tolerance
       while (7 - num_null_vectors_ >= 0 && s_[7 - num_null_vectors_] < _parameters.rank_tolerance) num_null_vectors_++;
       //while (s_[7 - num_null_vectors_] < _parameters.rank_tolerance) num_null_vectors_++;
+
       // Dimension of null space of Omega must be <= 6
       if (++num_null_vectors_ > 6) 
       {
@@ -522,7 +523,7 @@ namespace sqpnp
 				      Eigen::Matrix<double, 9, 6>& H, 
 				      Eigen::Matrix<double, 9, 3>& N,
 				      Eigen::Matrix<double, 6, 6>& K,
-				const double& norm_threhsold = 0.1 ); 
+				const double& norm_threshold = 0.1 ); 
    
   };
   

--- a/sqpnp/types.h
+++ b/sqpnp/types.h
@@ -105,6 +105,7 @@ namespace sqpnp
 
   };
   
+  enum class OmegaNullspaceMethod { RRQR, SVD };
   enum class NearestRotationMethod { FOAM, SVD };
   
   struct SolverParameters
@@ -113,6 +114,7 @@ namespace sqpnp
     static const double DEFAULT_SQP_SQUARED_TOLERANCE;
     static const double DEFAULT_SQP_DET_THRESHOLD;
     static const int DEFAULT_SQP_MAX_ITERATION = 15;
+    static const OmegaNullspaceMethod DEFAULT_OMEGA_NULLSPACE_METHOD;
     static const NearestRotationMethod DEFAULT_NEAREST_ROTATION_METHOD;
     static const double DEFAULT_ORTHOGONALITY_SQUARED_ERROR_THRESHOLD;
     static const double DEFAULT_EQUAL_VECTORS_SQUARED_DIFF;
@@ -123,6 +125,7 @@ namespace sqpnp
     double sqp_squared_tolerance;
     double sqp_det_threshold;
     int sqp_max_iteration;
+    OmegaNullspaceMethod omega_nullspace_method;
     NearestRotationMethod nearest_rotation_method;
     double orthogonality_squared_error_threshold;  
     double equal_vectors_squared_diff;
@@ -133,6 +136,7 @@ namespace sqpnp
 			    const double& _sqp_squared_tolerance = DEFAULT_SQP_SQUARED_TOLERANCE,
 			    const double& _sqp_det_threshold = DEFAULT_SQP_DET_THRESHOLD,
 			    const int _sqp_max_iteration = DEFAULT_SQP_MAX_ITERATION, 
+			    const OmegaNullspaceMethod& _omega_nullspace_method = DEFAULT_OMEGA_NULLSPACE_METHOD,
 			    const NearestRotationMethod& _nearest_rotation_method = DEFAULT_NEAREST_ROTATION_METHOD,
 			    const double& _orthogonality_squared_error_threshold = DEFAULT_ORTHOGONALITY_SQUARED_ERROR_THRESHOLD,
 		            const double& _equal_vectors_squared_diff = DEFAULT_EQUAL_VECTORS_SQUARED_DIFF,
@@ -142,6 +146,7 @@ namespace sqpnp
 				sqp_squared_tolerance(_sqp_squared_tolerance),
 				sqp_det_threshold(_sqp_det_threshold),
 				sqp_max_iteration(_sqp_max_iteration),
+				omega_nullspace_method(_omega_nullspace_method),
 				nearest_rotation_method(_nearest_rotation_method),
 				orthogonality_squared_error_threshold(_orthogonality_squared_error_threshold),
 				equal_vectors_squared_diff(_equal_vectors_squared_diff),


### PR DESCRIPTION
#16: Made default the nullspace computation of Omega with rank revealing QR. SVD-based computation retained as an alternative option. Removed the eigendecomposition.